### PR TITLE
Modernize build for current Ubuntu / CGAL 5.x / Python 3.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,18 @@ The current repository is modified from the original code snapshot recovered fro
 
 
 ## Platform
-* `Linux` (tested on `Ubuntu 14.04` and `Ubuntu 16.04`)
-* [`Windows Linux Subsystem`](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (tested on `Ubuntu 16.04 LTS`)
+* `Linux` (tested on `Ubuntu 20.04` and later)
+* [`Windows Subsystem for Linux`](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 
 ## Dependencies
 
-* `C++` toolchain: `sudo apt-get install build-essential autoconf libtool flex bison mercurial zsh cmake`.
+* `C++14` toolchain: `sudo apt-get install build-essential autoconf libtool flex bison cmake git`.
+* `Eigen3`: system install preferred (`sudo apt-get install libeigen3-dev`), falls back to vendored Eigen 3.3.4.
+* `CGAL >= 5.0`: `sudo apt-get install libcgal-dev`.
 * `Python 3.7+` (required by the latest sklearn)
-  - using a python distribution within a conda environment is highly recommended. You can follow [this tutorial]( https://www.microsoft.com/en-us/p/windows-terminal/9n0dx20hk701?rtc=1&activetab=pivot:overviewtab) to install miniconda on an ubuntu OS instance. Then, create and activate a conda environment with python 3.7 by: 
-  ```base
-  conda create -n inv_csg_env python=3.7 
-  conda activate inv_csg_env
-  python3 --version
-  # you should see "Python 3.7.7"
-  ```
+  - using a python distribution within a conda environment is highly recommended.
 * The latest `Sketch`.
-* `Java >= 1.8` (needed by `Sketch`).
+* `Java JDK` (`sudo apt-get install default-jdk`; needed by `Sketch`).
 * `maven >= 2.2.1` (needed by `Sketch`).
 
 ## Installation
@@ -46,12 +42,13 @@ You can see more options by `python3 install.py -h`.
 <details>
 You can also choose to do a manual installation if `install.py` fails to finish successfully.
 
-* Run
+* Install build tools and dependencies:
 
   ```bash
-  sudo apt-get install build-essential autoconf libtool flex bison mercurial zsh cmake
+  sudo apt-get install build-essential autoconf libtool flex bison cmake git
+  sudo apt-get install libcgal-dev
+  sudo apt-get install libeigen3-dev  # optional; vendored Eigen 3.3.4 used if absent
   ```
-
 
 * Navigate to your `build_folder`, create a `cpp` subfolder, and compile the `C++` code:
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,26 +3,31 @@ cmake_minimum_required(VERSION 3.1)
 project(csg_cpp_command)
 
 set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(UNIX)
-  add_definitions("-std=c++11 -Wall")
+  add_definitions("-Wall")
 elseif(MSVC)
   add_definitions("-D_CRT_SECURE_NO_WARNINGS")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
 endif()
 
-# Eigen.
-include_directories(lib/eigen-3.3.4)
+# Eigen: prefer system install, fall back to vendored copy.
+find_package(Eigen3 QUIET)
+if(Eigen3_FOUND AND TARGET Eigen3::Eigen)
+  message(STATUS "Using system Eigen3: ${Eigen3_DIR}")
+else()
+  message(STATUS "System Eigen3 not found, using vendored lib/eigen-3.3.4")
+  include_directories(lib/eigen-3.3.4)
+endif()
 # gco.
 include_directories(lib/gco-v3.0)
 add_subdirectory(lib/gco-v3.0)
-# CGAL.
-find_package(CGAL QUIET)
-if(CGAL_FOUND)
-  include(${CGAL_USE_FILE})
-  # CGAL include folder.
-  set(CGAL_INCLUDE_DIR "${CGAL_DIR}/include")
-  include_directories(${CGAL_INCLUDE_DIR})
+# CGAL (>= 5.0 required).
+find_package(CGAL 5.0 QUIET)
+if(NOT CGAL_FOUND)
+  message(FATAL_ERROR "CGAL not found. Install with: sudo apt-get install libcgal-dev")
 endif()
 
 set(SRC_DIR "src/")
@@ -31,3 +36,7 @@ file(GLOB_RECURSE CPP_HEADERS ${SRC_DIR}*.h)
 file(GLOB_RECURSE CPP_FILES ${SRC_DIR}*.cpp)
 add_executable(csg_cpp_command ${CPP_FILES} ${CPP_HEADERS})
 target_link_libraries(csg_cpp_command gco)
+if(Eigen3_FOUND AND TARGET Eigen3::Eigen)
+  target_link_libraries(csg_cpp_command Eigen3::Eigen)
+endif()
+target_link_libraries(csg_cpp_command CGAL::CGAL)

--- a/cpp/lib/gco-v3.0/energy.h
+++ b/cpp/lib/gco-v3.0/energy.h
@@ -259,9 +259,9 @@ inline void Energy<captype,tcaptype,flowtype>::add_term3(Var x, Var y, Var z,
                               Value E100, Value E101,
                               Value E110, Value E111)
 {
-	register Value pi = (E000 + E011 + E101 + E110) - (E100 + E010 + E001 + E111);
-	register Value delta;
-	register Var u;
+	Value pi = (E000 + E011 + E101 + E110) - (E100 + E010 + E001 + E111);
+	Value delta;
+	Var u;
 
 	if (pi >= 0)
 	{

--- a/cpp/src/ransac/cgal_ransac_wrapper.cpp
+++ b/cpp/src/ransac/cgal_ransac_wrapper.cpp
@@ -10,7 +10,7 @@
 #include "CGAL/property_map.h"
 #include "CGAL/Timer.h"
 #include "CGAL/number_utils.h"
-#include "CGAL/Shape_detection_3.h"
+#include "CGAL/Shape_detection/Efficient_RANSAC.h"
 #include "common/file_helper.h"
 #include "primitive/plane_surface.h"
 #include "primitive/cylindrical_surface.h"
@@ -29,14 +29,14 @@ typedef CGAL::Nth_of_tuple_property_map<0, PointWithNormal>  PointMap;
 typedef CGAL::Nth_of_tuple_property_map<1, PointWithNormal>  NormalMap;
 // In Shape_detection_traits the basic types, i.e., Point and Vector types
 // as well as iterator type and property maps, are defined.
-typedef CGAL::Shape_detection_3::Shape_detection_traits<Kernel,
+typedef CGAL::Shape_detection::Efficient_RANSAC_traits<Kernel,
     PwnVector, PointMap, NormalMap>            Traits;
-typedef CGAL::Shape_detection_3::Efficient_RANSAC<Traits>    EfficientRansac;
-typedef CGAL::Shape_detection_3::Plane<Traits>               Plane;
-typedef CGAL::Shape_detection_3::Sphere<Traits>              Sphere;
-typedef CGAL::Shape_detection_3::Cylinder<Traits>            Cylinder;
-typedef CGAL::Shape_detection_3::Cone<Traits>                Cone;
-typedef CGAL::Shape_detection_3::Torus<Traits>               Torus;
+typedef CGAL::Shape_detection::Efficient_RANSAC<Traits>    EfficientRansac;
+typedef CGAL::Shape_detection::Plane<Traits>               Plane;
+typedef CGAL::Shape_detection::Sphere<Traits>              Sphere;
+typedef CGAL::Shape_detection::Cylinder<Traits>            Cylinder;
+typedef CGAL::Shape_detection::Cone<Traits>                Cone;
+typedef CGAL::Shape_detection::Torus<Traits>               Torus;
 
 CgalRansacWrapper::CgalRansacWrapper(const mesh::TriMesh& shape)
   : shape_(shape), points_(3, 0), normals_(3, 0), point_to_face_(0),

--- a/cpp/src/test/test_initialize_surface_parameters.cpp
+++ b/cpp/src/test/test_initialize_surface_parameters.cpp
@@ -45,8 +45,14 @@ void TestInitializeSurfaceParameters(const std::string& conf_file,
     for (int i = 0; i < shape.NumOfFaces(); ++i) region[i] = i;
     vsa::QuadraticSurface quad_face(wrapper);
     quad_face.InitializeSurfaceParameters(region);
+    // Compute average squared radius so the target matches the actual mesh
+    // (the mesh is NOT a unit sphere — R ≈ 5).
+    double r_sq = 0.0;
+    for (int i = 0; i < shape.NumOfVertices(); ++i)
+      r_sq += shape.vertex(i).squaredNorm();
+    r_sq /= shape.NumOfVertices();
     Eigen::VectorXd target(10);
-    target << -1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0;
+    target << -r_sq, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0;
     Eigen::VectorXd estimate = quad_face.parameters();
     if (estimate(0) > 0) estimate = -estimate;
     target *= estimate.norm() / target.norm();

--- a/cpp/test.py
+++ b/cpp/test.py
@@ -49,3 +49,7 @@ for example in examples:
   # Print the bad examples so far.
   print('Bad examples so far:')
   print(bad_examples)
+
+if bad_examples:
+  print('Failed examples: %s' % bad_examples)
+  sys.exit(1)

--- a/helper.py
+++ b/helper.py
@@ -41,8 +41,10 @@ def Run(command, exception_handle=DefaultExceptionHandle, return_msg=False):
   print('Command finished in %f seconds.' % time_intvl)
   if return_msg:
     exit_code = ret_val
+  elif os.WIFEXITED(ret_val):
+    exit_code = os.WEXITSTATUS(ret_val)
   else:
-    exit_code = ret_val >> 8
+    exit_code = 1
 
   if exit_code != 0 and exception_handle is not None:
     exception_handle(command, exit_code)
@@ -83,16 +85,15 @@ def LoadOffMesh(off_file_name):
   return all_vertices, all_faces
 
 def SaveOffMesh(off_file_name, V, F):
-  f = open(off_file_name, 'w')
-  f.write('OFF\n')
-  vertex_num = V.shape[0]
-  face_num = F.shape[0]
-  f.write('%d %d 0\n' % (vertex_num, face_num))
-  for i in range(vertex_num):
-    f.write('%f %f %f\n' % (V[i, 0], V[i, 1], V[i, 2]))
-  for i in range(face_num):
-    f.write('3 %d %d %d\n' % (F[i, 0], F[i, 1], F[i, 2])) 
-  f.close()
+  with open(off_file_name, 'w') as f:
+    f.write('OFF\n')
+    vertex_num = V.shape[0]
+    face_num = F.shape[0]
+    f.write('%d %d 0\n' % (vertex_num, face_num))
+    for i in range(vertex_num):
+      f.write('%f %f %f\n' % (V[i, 0], V[i, 1], V[i, 2]))
+    for i in range(face_num):
+      f.write('3 %d %d %d\n' % (F[i, 0], F[i, 1], F[i, 2]))
 
 def GetOffMeshBoundingBox(off_file_name):
   v, _ = LoadOffMesh(off_file_name)
@@ -121,10 +122,9 @@ def SaveDataFile(data_file, points):
   if points.size == 0:
     number = int(0)
     all_bytes = number.to_bytes(4, sys.byteorder, signed=True)
-    f = open(data_file, 'w+b')
-    content = b''.join([all_bytes])
-    f.write(content)
-    f.close()
+    with open(data_file, 'w+b') as f:
+      content = b''.join([all_bytes])
+      f.write(content)
     return
 
   # Check inputs.
@@ -134,10 +134,9 @@ def SaveDataFile(data_file, points):
   number = int(points.shape[0])
   number_bytes = number.to_bytes(4, sys.byteorder, signed=True)
   data_bytes = points.astype(np.float64, 'C').tobytes('C')
-  f = open(data_file, 'w+b')
-  content = b''.join([number_bytes, data_bytes])
-  f.write(content)
-  f.close()
+  with open(data_file, 'w+b') as f:
+    content = b''.join([number_bytes, data_bytes])
+    f.write(content)
 
 ################################################################################
 # Convert points to sketch files.
@@ -147,33 +146,31 @@ def SavePointToSketch(data_file, idx_file, pos_points, neg_points):
   if pos_points.shape[1] != 3 or neg_points.shape[1] != 3:
     PrintWithRedColor('PointToSketch: incorrect input.')
     sys.exit(-1)
-  f = open(data_file, 'w')
-  num_pos = pos_points.shape[0]
-  num_neg = neg_points.shape[0]
-  if num_pos + num_neg <= 0:
-    PrintWithRedColor('PointToSketch: empty points.')
-    sys.exit(-1)
-  f.write('int NUM_DATA = %d;\n' % (num_pos + num_neg))
-  points = np.vstack((pos_points, neg_points))
-  all_x = ', '.join([str(float(x)) for x in points[:, 0]])
-  f.write('float[NUM_DATA] xs = {%s};\n' % all_x) 
-  all_y = ', '.join([str(float(y)) for y in points[:, 1]])
-  f.write('float[NUM_DATA] ys = {%s};\n' % all_y) 
-  all_z = ', '.join([str(float(z)) for z in points[:, 2]])
-  f.write('float[NUM_DATA] zs = {%s};\n' % all_z) 
-  all_labels = ', '.join(['1'] * num_pos + ['0'] * num_neg)
-  f.write('bit[NUM_DATA] labels = {%s};\n' % all_labels)
-  f.close()
+  with open(data_file, 'w') as f:
+    num_pos = pos_points.shape[0]
+    num_neg = neg_points.shape[0]
+    if num_pos + num_neg <= 0:
+      PrintWithRedColor('PointToSketch: empty points.')
+      sys.exit(-1)
+    f.write('int NUM_DATA = %d;\n' % (num_pos + num_neg))
+    points = np.vstack((pos_points, neg_points))
+    all_x = ', '.join([str(float(x)) for x in points[:, 0]])
+    f.write('float[NUM_DATA] xs = {%s};\n' % all_x)
+    all_y = ', '.join([str(float(y)) for y in points[:, 1]])
+    f.write('float[NUM_DATA] ys = {%s};\n' % all_y)
+    all_z = ', '.join([str(float(z)) for z in points[:, 2]])
+    f.write('float[NUM_DATA] zs = {%s};\n' % all_z)
+    all_labels = ', '.join(['1'] * num_pos + ['0'] * num_neg)
+    f.write('bit[NUM_DATA] labels = {%s};\n' % all_labels)
 
   # Write idx file.
-  f = open(idx_file, 'w')
-  all_idx = []
-  for i in range(num_pos + num_neg):
-    all_idx.append(i)
-  random.shuffle(all_idx)
-  for i in all_idx:
-    f.write('%d\n' % i)
-  f.close()
+  with open(idx_file, 'w') as f:
+    all_idx = []
+    for i in range(num_pos + num_neg):
+      all_idx.append(i)
+    random.shuffle(all_idx)
+    for i in all_idx:
+      f.write('%d\n' % i)
 
 ################################################################################
 # Point set operations.

--- a/helper.py
+++ b/helper.py
@@ -33,12 +33,16 @@ def Run(command, exception_handle=DefaultExceptionHandle, return_msg=False):
     ret_val = os.system(command)
   else:
     p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
-    ret_val = p.wait()
-    text = p.stdout.read().decode("utf-8").split('\n')[0]
+    stdout, _ = p.communicate()
+    text = stdout.decode("utf-8").split('\n')[0]
+    ret_val = p.returncode
 
   time_intvl = time.time() - time_start
   print('Command finished in %f seconds.' % time_intvl)
-  exit_code = ret_val >> 8
+  if return_msg:
+    exit_code = ret_val
+  else:
+    exit_code = ret_val >> 8
 
   if exit_code != 0 and exception_handle is not None:
     exception_handle(command, exit_code)

--- a/install.py
+++ b/install.py
@@ -1,6 +1,7 @@
 import os, sys, subprocess
 import readline, glob # For autocompleting file path.
 import urllib.request
+import shlex
 import shutil
 import helper
 import argparse
@@ -121,8 +122,8 @@ def InstallEigen(root_folder):
     helper.PrintWithGreenColor('System Eigen3 not found, downloading vendored copy...')
     cpp_lib_folder = os.path.join(root_folder, 'cpp', 'lib')
     zip_path = os.path.join(cpp_lib_folder, 'eigen-3.3.4.zip')
-    helper.Run('wget -q -O %s https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip' % zip_path)
-    helper.Run('unzip -o -q %s -d %s' % (zip_path, cpp_lib_folder))
+    helper.Run('wget -q -O %s https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip' % shlex.quote(zip_path))
+    helper.Run('unzip -o -q %s -d %s' % (shlex.quote(zip_path), shlex.quote(cpp_lib_folder)))
     os.remove(zip_path)
     # Rename extracted directory to match expected name (GitLab archives
     # may include a commit hash suffix like eigen-3.3.4-<hash>).
@@ -140,13 +141,13 @@ def InstallJava():
   # Currently JAVA_HOME is hard coded.
   # java_home = '/usr/lib/jvm/java-8-oracle/' 
   # java_home = '/usr/lib/jvm/java-8-openjdk-amd64'
-  java_path_cmd = "jrunscript -e \'java.lang.System.out.println(java.lang.System.getProperty(\"java.home\"));\'"
+  java_path_cmd = "dirname $(dirname $(readlink -f $(which java)))"
   java_home, _ = helper.Run(java_path_cmd, return_msg=True)
   env_variables['JAVA_HOME'] = os.environ['JAVA_HOME'] = java_home
   path = os.path.join(java_home, 'bin') + ':' + os.environ['PATH']
   env_variables['PATH'] = os.environ['PATH'] = path
   # helper.Run('%s -version' % os.path.join(java_home, 'bin', 'javac'))
-  helper.Run('%s -version' % os.path.join(java_home, 'bin', 'java'))
+  helper.Run('%s -version' % shlex.quote(os.path.join(java_home, 'bin', 'java')))
 
 def InstallMaven():
   # maven_url = 'http://mirrors.koehn.com/apache/maven/maven-3/3.5.3/' \
@@ -225,7 +226,7 @@ def main():
       os.makedirs(cpp_build_folder)
     if args.cpp:
       os.chdir(cpp_build_folder)
-      helper.Run('cmake %s' % os.path.join(root_folder, 'cpp'))
+      helper.Run('cmake %s' % shlex.quote(os.path.join(root_folder, 'cpp')))
       helper.Run('make')
       helper.PrintWithGreenColor('C++ program compiled successfully.')
     env_variables['CSG_CPP_EXE'] = os.path.join(cpp_build_folder,

--- a/install.py
+++ b/install.py
@@ -23,10 +23,10 @@ def AutoComplete(text, state):
   return (glob.glob(text + '*') + [None])[state]
 
 def SaveCustomizedEnvironmentVariables(env_variables, file_path):
-  f = open(file_path, 'w')
-  f.write('# You can manually change the environment variables below:\n')
-  for key, val in env_variables.items():
-    f.write('%s: %s\n' % (key, val))
+  with open(file_path, 'w') as f:
+    f.write('# You can manually change the environment variables below:\n')
+    for key, val in env_variables.items():
+      f.write('%s: %s\n' % (key, val))
 
 def CheckVersionNumber(version_number, target):
   major, minor, change = version_number.split('.')
@@ -108,43 +108,34 @@ def CheckSketch(build_folder):
 
   return True
 
-def InstallCGAL(build_folder, init=True):
-  helper.Run('sudo apt-get install libcgal-dev')
-  helper.PrintWithGreenColor('Installed libcgal-dev')
-  if init:
-    cgal_url = 'https://github.com/CGAL/cgal/releases/download/' \
-               'releases%2FCGAL-4.12/CGAL-4.12.zip'
-    cgal_file = os.path.join(build_folder, 'cgal.zip')
-    urllib.request.urlretrieve(cgal_url, cgal_file)
-    helper.Run('unzip -o -q %s -d %s' % (cgal_file, build_folder))
-    os.remove(cgal_file)
-  # Now you have the source code.
-  helper.PrintWithGreenColor('Downloaded and unzipped CGAL 4.12')
-  cgal_dir = ''
-  for folder_name in os.listdir(build_folder):
-    if 'cgal' in folder_name or 'CGAL' in folder_name:
-      cgal_dir = os.path.join(build_folder, folder_name)
-      break
-  # Add cgal_root to the environment variable list.
-  env_variables['CGAL_DIR'] = os.environ['CGAL_DIR'] = cgal_dir
+def InstallCGAL():
+  helper.Run('sudo apt-get install -y libcgal-dev')
+  helper.PrintWithGreenColor('Installed libcgal-dev (system package)')
 
-def InstallEigen(root_folder, init=True):
-  if init:
-    # helper.Run('wget http://bitbucket.org/eigen/eigen/get/3.3.4.zip')
-    helper.Run('wget https://github.com/eigenteam/eigen-git-mirror/archive/3.3.4.zip')
+def InstallEigen(root_folder):
+  # Prefer system Eigen3. Fall back to downloading vendored copy.
+  exit_code = helper.Run('dpkg -s libeigen3-dev', None)
+  if exit_code == 0:
+    helper.PrintWithGreenColor('Using system Eigen3 (libeigen3-dev)')
+  else:
+    helper.PrintWithGreenColor('System Eigen3 not found, downloading vendored copy...')
     cpp_lib_folder = os.path.join(root_folder, 'cpp', 'lib')
-    helper.Run('unzip 3.3.4.zip -d %s' % os.path.join(cpp_lib_folder))
-    helper.Run('mv %s %s' % (os.path.join(cpp_lib_folder, \
-     'eigen-git-mirror-3.3.4'), os.path.join(cpp_lib_folder, 'eigen-3.3.4')))
-    helper.Run('rm 3.3.4.zip')
-    helper.PrintWithGreenColor('Installed Eigen')
+    zip_path = os.path.join(cpp_lib_folder, 'eigen-3.3.4.zip')
+    helper.Run('wget -q -O %s https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip' % zip_path)
+    helper.Run('unzip -o -q %s -d %s' % (zip_path, cpp_lib_folder))
+    os.remove(zip_path)
+    # Rename extracted directory to match expected name (GitLab archives
+    # may include a commit hash suffix like eigen-3.3.4-<hash>).
+    expected = os.path.join(cpp_lib_folder, 'eigen-3.3.4')
+    if not os.path.isdir(expected):
+      for name in os.listdir(cpp_lib_folder):
+        if name.startswith('eigen-3.3.4'):
+          os.rename(os.path.join(cpp_lib_folder, name), expected)
+          break
+    helper.PrintWithGreenColor('Installed vendored Eigen 3.3.4')
 
 def InstallJava():
-  # java not hosted anymore: http://www.webupd8.org/2014/03/how-to-install-oracle-java-8-in-debian.html
-  # helper.Run('sudo add-apt-repository -y ppa:webupd8team/java')
-  # helper.Run('sudo apt-get update')
-  # helper.Run('sudo apt-get install oracle-java8-installer')
-  helper.Run('sudo apt-get install openjdk-8-jre')
+  helper.Run('sudo apt-get install -y default-jdk')
 
   # Currently JAVA_HOME is hard coded.
   # java_home = '/usr/lib/jvm/java-8-oracle/' 
@@ -170,7 +161,7 @@ def InstallMaven():
   #     maven_loc = os.path.join(build_folder, folder_name, 'bin')
   #     env_variables['PATH'] = os.environ['PATH'] \
   #                           = maven_loc + ':' + os.environ['PATH']
-  helper.Run('sudo apt-get install build-essential autoconf libtool flex bison mercurial maven')
+  helper.Run('sudo apt-get install -y maven')
   # Check maven.
   helper.Run('mvn -v')
 
@@ -210,36 +201,23 @@ def main():
     
     # Check all C++ dependencies.
     if args.deps:
-      print('Attempt to install build-essential, autoconf, libtool, flex, bison, '
-            'mecurial, zsh, and cmake. Asking for sudo privilege.')
-      # This works for Ubuntu 17.04 and 16.04.
-      exit_code = helper.Run('sudo apt-get install gcc-6 g++-6 -y', None)
-      if exit_code != 0:
-        # This works for Ubuntu 14.04.
-        helper.Run('sudo apt-get update')
-        helper.Run('sudo apt-get install build-essential ' \
-          'software-properties-common -y')
-        helper.Run('sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y')
-        helper.Run('sudo apt-get update')
-        helper.Run('sudo apt-get install gcc-snapshot -y')
-        helper.Run('sudo apt-get update')
-        helper.Run('sudo apt-get install gcc-6 g++-6 -y')
-        helper.Run('sudo apt-get install autoconf libtool flex bison '
-          'mercurial zsh cmake git')
-    
+      print('Installing build tools and dependencies...')
+      helper.Run('sudo apt-get update')
+      helper.Run('sudo apt-get install -y build-essential autoconf libtool '
+        'flex bison cmake git')
+
       # Install python dependencies.
-      # TODO check if python version >= 3.7
+      os.environ['PIP_BREAK_SYSTEM_PACKAGES'] = '1'
       helper.Run('python3 -m pip install -U pip setuptools')
-      helper.Run('python3 -m pip install --upgrade pip')
-      helper.Run('python3 -m pip install numpy scipy matplotlib ipython '
-                 'jupyter pandas sympy nose')
-      helper.Run('python3 -m pip install -U scikit-learn')
+      helper.Run('python3 -m pip install numpy scipy matplotlib scikit-learn')
     
     # Install CGAL.
-    InstallCGAL(build_folder, args.eigen)
-    
+    if args.cgal:
+      InstallCGAL()
+
     # Install Eigen-3.3.4.
-    InstallEigen(root_folder, args.cgal)
+    if args.eigen:
+      InstallEigen(root_folder)
     
     # Compile cpp.
     cpp_build_folder = os.path.join(build_folder, 'cpp')
@@ -247,10 +225,7 @@ def main():
       os.makedirs(cpp_build_folder)
     if args.cpp:
       os.chdir(cpp_build_folder)
-      os.environ['CC'] = '/usr/bin/gcc-6'
-      os.environ['CXX'] = '/usr/bin/g++-6'
-      helper.Run('cmake -DCGAL_DIR=%s %s' % (env_variables['CGAL_DIR'], \
-                                             os.path.join(root_folder, 'cpp')))
+      helper.Run('cmake %s' % os.path.join(root_folder, 'cpp'))
       helper.Run('make')
       helper.PrintWithGreenColor('C++ program compiled successfully.')
     env_variables['CSG_CPP_EXE'] = os.path.join(cpp_build_folder,
@@ -265,8 +240,8 @@ def main():
       sys.exit(0)
     
     # If we are here, Sketch is not properly installed.
-    # First, install Oracle JDK 8.
-    print('Attempt to install Oracle JDK 8. Asking for sudo privilege.')
+    # First, install Java JDK.
+    print('Attempt to install Java JDK. Asking for sudo privilege.')
     InstallJava()
     
     # Next, install maven.

--- a/point_cloud_seg.py
+++ b/point_cloud_seg.py
@@ -17,12 +17,21 @@ def SegmentPointCloud(data_file, seg_num, seg_file_prefix, visualize=False):
     ax.set_ylabel('y')
     ax.set_zlabel('z')
     plt.show()
-  # Clustering.
-  cluster_result = cluster.AgglomerativeClustering(n_clusters = seg_num)
-  cluster_result.fit(points)
-  labels = cluster_result.labels_.astype(int)
+  # Clustering. Guard against n_clusters > n_samples (upstream issue #1).
+  n_samples = points.shape[0]
+  actual_seg_num = min(seg_num, n_samples)
+  if actual_seg_num < seg_num:
+    print('Warning: only %d sample(s), reducing n_clusters from %d to %d.' %
+          (n_samples, seg_num, actual_seg_num))
+  if actual_seg_num <= 1:
+    # Cannot cluster with 0 or 1 samples — assign all to segment 0.
+    labels = np.zeros(n_samples, dtype=int)
+  else:
+    cluster_result = cluster.AgglomerativeClustering(n_clusters = actual_seg_num)
+    cluster_result.fit(points)
+    labels = cluster_result.labels_.astype(int)
   # Display the segmentation results.
-  if visualize:
+  if visualize and n_samples > 0:
     colors = np.array(list(islice(cycle(['#377eb8', '#ff7f00', '#4daf4a',
       '#f781bf', '#a65628', '#984ea3', '#999999', '#e41a1c', '#dede00',
       '#000000']), int(max(labels) + 1))))
@@ -35,10 +44,11 @@ def SegmentPointCloud(data_file, seg_num, seg_file_prefix, visualize=False):
     plt.show()
   # Save all segmentation results into file. The file names will be:
   # seg_file_prefix_0.data, seg_file_prefix_1.data, ...
-  for i in range(seg_num):
+  for i in range(actual_seg_num):
     seg_file_name = seg_file_prefix + '_' + str(i) + '.data'
     seg_points = points[np.array(labels)==i, :]
     helper.SaveDataFile(seg_file_name, seg_points)
+  return actual_seg_num
 
 if __name__ == '__main__':
   # Usage: python3 point_cloud_seg.py <data_file> <seg_num> <seg_file_prefix> <visualize>

--- a/point_cloud_seg.py
+++ b/point_cloud_seg.py
@@ -4,7 +4,6 @@ import numpy as np
 import helper
 from sklearn import cluster, mixture
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 from itertools import cycle, islice
 
 def SegmentPointCloud(data_file, seg_num, seg_file_prefix, visualize=False):
@@ -12,29 +11,27 @@ def SegmentPointCloud(data_file, seg_num, seg_file_prefix, visualize=False):
   points = helper.LoadDataFile(data_file)
   if visualize:
     fig = plt.figure()
-    ax = Axes3D(fig)
+    ax = fig.add_subplot(111, projection='3d')
     ax.scatter(points[:, 0], points[:, 1], points[:, 2], c = 'r')
     ax.set_xlabel('x')
     ax.set_ylabel('y')
     ax.set_zlabel('z')
-    ax.set_aspect('equal')
     plt.show()
   # Clustering.
   cluster_result = cluster.AgglomerativeClustering(n_clusters = seg_num)
   cluster_result.fit(points)
-  labels = cluster_result.labels_.astype(np.int)
+  labels = cluster_result.labels_.astype(int)
   # Display the segmentation results.
   if visualize:
     colors = np.array(list(islice(cycle(['#377eb8', '#ff7f00', '#4daf4a',
       '#f781bf', '#a65628', '#984ea3', '#999999', '#e41a1c', '#dede00',
       '#000000']), int(max(labels) + 1))))
     fig = plt.figure()
-    ax = Axes3D(fig)
+    ax = fig.add_subplot(111, projection='3d')
     ax.scatter(points[:, 0], points[:, 1], points[:, 2], color = colors[labels])
     ax.set_xlabel('x')
     ax.set_ylabel('y')
     ax.set_zlabel('z')
-    ax.set_aspect('equal')
     plt.show()
   # Save all segmentation results into file. The file names will be:
   # seg_file_prefix_0.data, seg_file_prefix_1.data, ...

--- a/primitive_to_sketch.py
+++ b/primitive_to_sketch.py
@@ -573,7 +573,7 @@ def WriteSketchFile(file_name, spheres, rotations_and_offsets, cylinder_hints, \
 
   # Generate cuboid hints.
   def PrintList(l):
-    return str(l).replace('[', '{').replace(']', '}')
+    return str([float(x) for x in l]).replace('[', '{').replace(']', '}')
   def GenerateCuboidHint(rotation_and_offset):
     coord, x, y, z = rotation_and_offset
     roll, pitch, yaw = CoordToEulerAngle(coord)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import sys
 
 # Usage: python3 run_tests.py <build_dir> <test_name>
@@ -12,221 +13,231 @@ if len(sys.argv) < 3:
   print('Error: please specify the test case name.')
   sys.exit(-1)
 
-build_dir = sys.argv[1]
+build_dir = shlex.quote(sys.argv[1])
 test_name = sys.argv[2]
 
+def run_test(cmd):
+  ret = os.system(cmd)
+  if os.WIFEXITED(ret):
+    exit_code = os.WEXITSTATUS(ret)
+  else:
+    exit_code = 1
+  if exit_code != 0:
+    print('Test failed with exit code %d' % exit_code)
+    sys.exit(exit_code)
+
 if test_name == 'one_cube':
-  os.system('python3 main.py --builddir %s --outdir ../one_cube --mesh example/one_cube/csg_low_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../one_cube --mesh example/one_cube/csg_low_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
 elif test_name == 'rotated_cuboid':
-  os.system('python3 main.py --builddir %s --outdir ../rotated_cuboid --mesh example/rotated_cuboid/csg_low_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../rotated_cuboid --mesh example/rotated_cuboid/csg_low_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
 elif test_name == 'two_cuboids':
-  os.system('python3 main.py --builddir %s --outdir ../two_cuboids --mesh example/two_cuboids/csg_low_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../two_cuboids --mesh example/two_cuboids/csg_low_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
 elif test_name == 'one_sphere':
-  os.system('python3 main.py --builddir %s --outdir ../one_sphere --mesh example/one_sphere/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../one_sphere --mesh example/one_sphere/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
 elif test_name == 'one_cylinder':
-  os.system('python3 main.py --builddir %s --outdir ../one_cylinder --mesh example/one_cylinder/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../one_cylinder --mesh example/one_cylinder/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
 elif test_name == 'rotated_cylinder':
-  os.system('python3 main.py --builddir %s --outdir ../rotated_cylinder --mesh example/rotated_cylinder/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../rotated_cylinder --mesh example/rotated_cylinder/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
 elif test_name == 'three_cuboids_one_cylinder':
-  os.system('python3 main.py --builddir %s --outdir ../three_cuboids_one_cylinder --mesh example/three_cuboids_one_cylinder/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../three_cuboids_one_cylinder --mesh example/three_cuboids_one_cylinder/csg_high_res.off --eps 0.1 --surfacedensity 100 --volumedensity 10' % build_dir)
 elif test_name == 'torus':
-  os.system('python3 main.py --builddir %s --outdir ../torus --mesh example/torus/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../torus --mesh example/torus/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100' % build_dir)
 elif test_name == 'torus_cube':
-  os.system('python3 main.py --builddir %s --outdir ../torus_cube --mesh example/torus_cube/csg_high_res.off --eps 0.1 --surfacedensity 400 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../torus_cube --mesh example/torus_cube/csg_high_res.off --eps 0.1 --surfacedensity 400 --volumedensity 100' % build_dir)
 elif test_name == 'single_torus':
-  os.system('python3 main.py --builddir %s --outdir ../single_torus --mesh example/single_torus/csg_high_res.off --eps 0.1 --surfacedensity 40 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../single_torus --mesh example/single_torus/csg_high_res.off --eps 0.1 --surfacedensity 40 --volumedensity 10' % build_dir)
 elif test_name == 'spot':
-  os.system('python3 main.py --builddir %s --outdir ../spot --mesh example/spot/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100 --timeout 180' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../spot --mesh example/spot/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100 --timeout 180' % build_dir)
 elif test_name == 'double_torus':
-  os.system('python3 main.py --builddir %s --outdir ../double_torus --mesh example/double_torus/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../double_torus --mesh example/double_torus/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100' % build_dir)
 elif test_name == 'bunny':
-  os.system('python3 main.py --builddir %s --outdir ../bunny --mesh example/bunny/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../bunny --mesh example/bunny/csg_high_res.off --eps 0.1 --surfacedensity 4000 --volumedensity 100' % build_dir)
 elif test_name == 'ex_163':
-  os.system('python3 main.py --builddir %s --outdir ../ex_163 --mesh example/163/csg_high_res.off --eps 0.05 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_163 --mesh example/163/csg_high_res.off --eps 0.05 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_164':
-  os.system('python3 main.py --builddir %s --outdir ../ex_164 --mesh example/164/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_164 --mesh example/164/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 100' % build_dir)
 elif test_name == 'ex_165':
-  os.system('python3 main.py --builddir %s --outdir ../ex_165 --mesh example/165/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_165 --mesh example/165/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 100' % build_dir)
 elif test_name == 'ex_166':
-  os.system('python3 main.py --builddir %s --outdir ../ex_166 --mesh example/166/csg_high_res.off --eps 0.05 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_166 --mesh example/166/csg_high_res.off --eps 0.05 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_167':
-  os.system('python3 main.py --builddir %s --outdir ../ex_167 --mesh example/167/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_167 --mesh example/167/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_168':
-  os.system('python3 main.py --builddir %s --outdir ../ex_168 --mesh example/168/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_168 --mesh example/168/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_169':
-  os.system('python3 main.py --builddir %s --outdir ../ex_169 --mesh example/169/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_169 --mesh example/169/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_170':
-  os.system('python3 main.py --builddir %s --outdir ../ex_170 --mesh example/170/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_170 --mesh example/170/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_171':
-  os.system('python3 main.py --builddir %s --outdir ../ex_171 --mesh example/171/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_171 --mesh example/171/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_172':
-  os.system('python3 main.py --builddir %s --outdir ../ex_172 --mesh example/172/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_172 --mesh example/172/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_173':
-  os.system('python3 main.py --builddir %s --outdir ../ex_173 --mesh example/173/csg_high_res.off --eps 0.02 --surfacedensity 4000 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_173 --mesh example/173/csg_high_res.off --eps 0.02 --surfacedensity 4000 --volumedensity 100' % build_dir)
 elif test_name == 'ex_174':
-  os.system('python3 main.py --builddir %s --outdir ../ex_174 --mesh example/174/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_174 --mesh example/174/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_175':
-  os.system('python3 main.py --builddir %s --outdir ../ex_175 --mesh example/175/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_175 --mesh example/175/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_176':
-  os.system('python3 main.py --builddir %s --outdir ../ex_176 --mesh example/176/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_176 --mesh example/176/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'base':
-  os.system('python3 main.py --builddir %s --outdir ../base --mesh example/base/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../base --mesh example/base/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 25' % build_dir)
 elif test_name == 'ex_162':
-  os.system('python3 main.py --builddir %s --outdir ../162 --mesh example/162/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../162 --mesh example/162/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 25' % build_dir)
 elif test_name == 'hallway':
-  os.system('python3 main.py --builddir %s --outdir ../hallway --mesh example/hallway/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 100' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../hallway --mesh example/hallway/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 100' % build_dir)
 elif test_name == 'ex_161':
-  os.system('python3 main.py --builddir %s --outdir ../161 --mesh example/161/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../161 --mesh example/161/csg_high_res.off --eps 0.02 --surfacedensity 2000 --volumedensity 25' % build_dir)
 elif test_name == 'ex_160':
-  os.system('python3 main.py --builddir %s --outdir ../ex_160 --mesh example/160/csg_high_res.off --initsample 100 --countersample 100 --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_160 --mesh example/160/csg_high_res.off --initsample 100 --countersample 100 --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_011':
-  os.system('python3 main.py --builddir %s --outdir ../ex_011 --mesh example/011/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_011 --mesh example/011/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_023':
-  os.system('python3 main.py --builddir %s --outdir ../ex_023 --mesh example/023/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25 --timeout 1800' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_023 --mesh example/023/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25 --timeout 1800' % build_dir)
 elif test_name == 'ex_039':
-  os.system('python3 main.py --builddir %s --outdir ../ex_039 --mesh example/039/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_039 --mesh example/039/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_040':
-  os.system('python3 main.py --builddir %s --outdir ../ex_040 --mesh example/040/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_040 --mesh example/040/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_041':
-  os.system('python3 main.py --builddir %s --outdir ../ex_041 --mesh example/041/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_041 --mesh example/041/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_043':
-  os.system('python3 main.py --builddir %s --outdir ../ex_043 --mesh example/043/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_043 --mesh example/043/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_045':
-  os.system('python3 main.py --builddir %s --outdir ../ex_045 --mesh example/045/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_045 --mesh example/045/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_046':
-  os.system('python3 main.py --builddir %s --outdir ../ex_046 --mesh example/046/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_046 --mesh example/046/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_050':
-  os.system('python3 main.py --builddir %s --outdir ../ex_050 --mesh example/050/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_050 --mesh example/050/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_054':
-  os.system('python3 main.py --builddir %s --outdir ../ex_054 --mesh example/054/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_054 --mesh example/054/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_056':
-  os.system('python3 main.py --builddir %s --outdir ../ex_056 --mesh example/056/csg_high_res.off --eps 0.02 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_056 --mesh example/056/csg_high_res.off --eps 0.02 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_057':
-  os.system('python3 main.py --builddir %s --outdir ../ex_057 --mesh example/057/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_057 --mesh example/057/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_059':
-  os.system('python3 main.py --builddir %s --outdir ../ex_059 --mesh example/059/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_059 --mesh example/059/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_060':
-  os.system('python3 main.py --builddir %s --outdir ../ex_060 --mesh example/060/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_060 --mesh example/060/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_062':
-  os.system('python3 main.py --builddir %s --outdir ../ex_062 --mesh example/062/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_062 --mesh example/062/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_065':
-  os.system('python3 main.py --builddir %s --outdir ../ex_065 --mesh example/065/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_065 --mesh example/065/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_066':
-  os.system('python3 main.py --builddir %s --outdir ../ex_066 --mesh example/066/csg_high_res.off --eps 0.02 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_066 --mesh example/066/csg_high_res.off --eps 0.02 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_067':
-  os.system('python3 main.py --builddir %s --outdir ../ex_067 --mesh example/067/csg_high_res.off --eps 0.05 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_067 --mesh example/067/csg_high_res.off --eps 0.05 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_068':
-  os.system('python3 main.py --builddir %s --outdir ../ex_068 --mesh example/068/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_068 --mesh example/068/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_069':
-  os.system('python3 main.py --builddir %s --outdir ../ex_069 --mesh example/069/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_069 --mesh example/069/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_072':
-  os.system('python3 main.py --builddir %s --outdir ../ex_072 --mesh example/072/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_072 --mesh example/072/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_074':
-  os.system('python3 main.py --builddir %s --outdir ../ex_074 --mesh example/074/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_074 --mesh example/074/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_075':
-  os.system('python3 main.py --builddir %s --outdir ../ex_075 --mesh example/075/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_075 --mesh example/075/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_078':
-  os.system('python3 main.py --builddir %s --outdir ../ex_078 --mesh example/081/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_078 --mesh example/081/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_079':
-  os.system('python3 main.py --builddir %s --outdir ../ex_079 --mesh example/079/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_079 --mesh example/079/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_081':
-  os.system('python3 main.py --builddir %s --outdir ../ex_081 --mesh example/081/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_081 --mesh example/081/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_082':
-  os.system('python3 main.py --builddir %s --outdir ../ex_082 --mesh example/082/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_082 --mesh example/082/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_090':
-  os.system('python3 main.py --builddir %s --outdir ../ex_090 --mesh example/090/csg_high_res.off --eps 0.05 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_090 --mesh example/090/csg_high_res.off --eps 0.05 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_091':
-  os.system('python3 main.py --builddir %s --outdir ../ex_091 --mesh example/091/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_091 --mesh example/091/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_096':
-  os.system('python3 main.py --builddir %s --outdir ../ex_096 --mesh example/096/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_096 --mesh example/096/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_098':
-  os.system('python3 main.py --builddir %s --outdir ../ex_098 --mesh example/098/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_098 --mesh example/098/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_101':
-  os.system('python3 main.py --builddir %s --outdir ../ex_101 --mesh example/101/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_101 --mesh example/101/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_102':
-  os.system('python3 main.py --builddir %s --outdir ../ex_102 --mesh example/102/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_102 --mesh example/102/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_103':
-  os.system('python3 main.py --builddir %s --outdir ../ex_103 --mesh example/105/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_103 --mesh example/105/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_104':
-  os.system('python3 main.py --builddir %s --outdir ../ex_104 --mesh example/104/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_104 --mesh example/104/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_105':
-  os.system('python3 main.py --builddir %s --outdir ../ex_105 --mesh example/105/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_105 --mesh example/105/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_106':
-  os.system('python3 main.py --builddir %s --outdir ../ex_106 --mesh example/106/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_106 --mesh example/106/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_107':
-  os.system('python3 main.py --builddir %s --outdir ../ex_107 --mesh example/107/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_107 --mesh example/107/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_108':
-  os.system('python3 main.py --builddir %s --outdir ../ex_108 --mesh example/108/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_108 --mesh example/108/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_109':
-  os.system('python3 main.py --builddir %s --outdir ../ex_109 --mesh example/109/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_109 --mesh example/109/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_111':
-  os.system('python3 main.py --builddir %s --outdir ../ex_111 --mesh example/111/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_111 --mesh example/111/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_112':
-  os.system('python3 main.py --builddir %s --outdir ../ex_112 --mesh example/112/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_112 --mesh example/112/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_114':
-  os.system('python3 main.py --builddir %s --outdir ../ex_114 --mesh example/114/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_114 --mesh example/114/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_115':
-  os.system('python3 main.py --builddir %s --outdir ../ex_115 --mesh example/115/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_115 --mesh example/115/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_117':
-  os.system('python3 main.py --builddir %s --outdir ../ex_117 --mesh example/117/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_117 --mesh example/117/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_118':
-  os.system('python3 main.py --builddir %s --outdir ../ex_118 --mesh example/118/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_118 --mesh example/118/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_122':
-  os.system('python3 main.py --builddir %s --outdir ../ex_122 --mesh example/122/csg_high_res.off --eps 0.01 --surfacedensity 2000 --volumedensity 50' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_122 --mesh example/122/csg_high_res.off --eps 0.01 --surfacedensity 2000 --volumedensity 50' % build_dir)
 elif test_name == 'ex_123':
-  os.system('python3 main.py --builddir %s --outdir ../ex_123 --mesh example/123/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_123 --mesh example/123/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_126':
-  os.system('python3 main.py --builddir %s --outdir ../ex_126 --mesh example/126/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_126 --mesh example/126/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_127':
-  os.system('python3 main.py --builddir %s --outdir ../ex_127 --mesh example/127/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_127 --mesh example/127/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_128':
-  os.system('python3 main.py --builddir %s --outdir ../ex_128 --mesh example/128/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_128 --mesh example/128/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_129':
-  os.system('python3 main.py --builddir %s --outdir ../ex_129 --mesh example/129/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_129 --mesh example/129/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_130':
-  os.system('python3 main.py --builddir %s --outdir ../ex_130 --mesh example/130/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_130 --mesh example/130/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_131':
-  os.system('python3 main.py --builddir %s --outdir ../ex_131 --mesh example/131/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_131 --mesh example/131/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_133':
-  os.system('python3 main.py --builddir %s --outdir ../ex_133 --mesh example/133/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_133 --mesh example/133/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_134':
-  os.system('python3 main.py --builddir %s --outdir ../ex_134 --mesh example/134/csg_high_res.off --eps 0.05 --surfacedensity 1000 --volumedensity 10' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_134 --mesh example/134/csg_high_res.off --eps 0.05 --surfacedensity 1000 --volumedensity 10' % build_dir)
 elif test_name == 'ex_139':
-  os.system('python3 main.py --builddir %s --outdir ../ex_139 --mesh example/139/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_139 --mesh example/139/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_140':
-  os.system('python3 main.py --builddir %s --outdir ../ex_140 --mesh example/140/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 50' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_140 --mesh example/140/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 50' % build_dir)
 elif test_name == 'ex_142':
-  os.system('python3 main.py --builddir %s --outdir ../ex_142 --mesh example/142/csg_high_res.off --eps 0.01 --surfacedensity 2000 --volumedensity 50' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_142 --mesh example/142/csg_high_res.off --eps 0.01 --surfacedensity 2000 --volumedensity 50' % build_dir)
 elif test_name == 'ex_143':
-  os.system('python3 main.py --builddir %s --outdir ../ex_143 --mesh example/143/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_143 --mesh example/143/csg_high_res.off --eps 0.01 --surfacedensity 1000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_144':
-  os.system('python3 main.py --builddir %s --outdir ../ex_144 --mesh example/144/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_144 --mesh example/144/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_145':
-  os.system('python3 main.py --builddir %s --outdir ../ex_145 --mesh example/145/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_145 --mesh example/145/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_146':
-  os.system('python3 main.py --builddir %s --outdir ../ex_146 --mesh example/146/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_146 --mesh example/146/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_147':
-  os.system('python3 main.py --builddir %s --outdir ../ex_147 --mesh example/147/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_147 --mesh example/147/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_148':
-  os.system('python3 main.py --builddir %s --outdir ../ex_148 --mesh example/148/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_148 --mesh example/148/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_150':
-  os.system('python3 main.py --builddir %s --outdir ../ex_150 --mesh example/150/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_150 --mesh example/150/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_151':
-  os.system('python3 main.py --builddir %s --outdir ../ex_151 --mesh example/151/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_151 --mesh example/151/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_152':
-  os.system('python3 main.py --builddir %s --outdir ../ex_152 --mesh example/152/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_152 --mesh example/152/csg_high_res.off --eps 0.01 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_153':
-  os.system('python3 main.py --builddir %s --outdir ../ex_153 --mesh example/153/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 25 --timeout 600' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_153 --mesh example/153/csg_high_res.off --eps 0.02 --surfacedensity 1000 --volumedensity 25 --timeout 600' % build_dir)
 elif test_name == 'ex_155':
-  os.system('python3 main.py --builddir %s --outdir ../ex_155 --mesh example/155/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_155 --mesh example/155/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_156':
-  os.system('python3 main.py --builddir %s --outdir ../ex_156 --mesh example/156/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_156 --mesh example/156/csg_high_res.off --eps 0.01 --surfacedensity 4000 --volumedensity 200' % build_dir)
 elif test_name == 'ex_157':
-  os.system('python3 main.py --builddir %s --outdir ../ex_157 --mesh example/157/csg_high_res.off --eps 0.1 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_157 --mesh example/157/csg_high_res.off --eps 0.1 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_158':
-  os.system('python3 main.py --builddir %s --outdir ../ex_158 --mesh example/158/csg_high_res.off --eps 0.1 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_158 --mesh example/158/csg_high_res.off --eps 0.1 --surfacedensity 250 --volumedensity 25' % build_dir)
 elif test_name == 'ex_159':
-  os.system('python3 main.py --builddir %s --outdir ../ex_159 --mesh example/159/csg_high_res.off --eps 0.025 --surfacedensity 250 --volumedensity 25' % build_dir)
+  run_test('python3 main.py --builddir %s --outdir ../ex_159 --mesh example/159/csg_high_res.off --eps 0.025 --surfacedensity 250 --volumedensity 25' % build_dir)
 else:
   print('Unknown test case: %s' % test_name)
   sys.exit(-1)

--- a/sketch_pipeline.py
+++ b/sketch_pipeline.py
@@ -96,7 +96,7 @@ def SetupSketchPipeline(args):
     os.makedirs(output_dir)
   if surface_density <= 0:
     print('Warning: invalid surface density. Use 10000 instead.')
-    sample_density = 10000
+    surface_density = 10000
   if seg_num <= 1:
     print('Warning: invalid seg num. Use 2 instead.')
     seg_num = 2

--- a/sketch_pipeline.py
+++ b/sketch_pipeline.py
@@ -641,8 +641,9 @@ def RunSketchPipeline():
   # Major loop starts here.
   part_file = os.path.join(point_output_dir, 'part_0.data')
   shutil.copy(mesh_info['vol_pos_file'], part_file)
-  todo = [part_file] 
+  todo = [part_file]
   solutions = []
+  skipped_parts = []
   while len(todo) > 0:
     # Pop the first element.
     part_file = todo[0]
@@ -714,19 +715,31 @@ def RunSketchPipeline():
         return
     else:
       # Segment the volume.
-      point_cloud_seg.SegmentPointCloud(part_file, seg_num, \
+      actual_seg_num = point_cloud_seg.SegmentPointCloud(part_file, seg_num, \
         part_file[:-len('.data')])
+      if actual_seg_num <= 1:
+        # Cannot subdivide further — skip to avoid infinite loop.
+        print('Warning: part %d could not be segmented further, skipping.' % idx)
+        skipped_parts.append(idx)
+        continue
       # Get the last idx.
       last_part_file = todo[-1] if len(todo) > 0 else part_file
       last_idx = int(last_part_file[last_part_file.rfind('_') + 1 \
-        : -len('.data')]) 
+        : -len('.data')])
       new_idx = last_idx + 1
-      for i in range(seg_num):
+      for i in range(actual_seg_num):
         new_part_file = \
           part_file[:part_file.rfind('_') + 1] + str(new_idx + i) + '.data'
         shutil.copyfile(part_file[:-len('.data')] + '_' + str(i) + '.data' , \
           new_part_file)
         todo.append(new_part_file)
+
+  # If any parts were skipped, the solution is incomplete.
+  if skipped_parts:
+    helper.PrintWithRedColor(
+      'Error: parts %s could not be solved or subdivided. '
+      'The result has missing geometry.' % skipped_parts)
+    sys.exit(-1)
 
 if __name__ == '__main__':
   pass

--- a/surface_primitive_to_sketch.py
+++ b/surface_primitive_to_sketch.py
@@ -698,7 +698,7 @@ def WriteSolidPrimitivesToSketch(file_name, spheres, rotations_and_offsets, \
 
   # Generate cuboid hints.
   def PrintList(l):
-    return str(l).replace('[', '{').replace(']', '}')
+    return str([float(x) for x in l]).replace('[', '{').replace(']', '}')
   def GenerateCuboidHint(rotation_and_offset):
     coord, x, y, z = rotation_and_offset
     roll, pitch, yaw = CoordToEulerAngle(coord)

--- a/visualize_point_cloud.py
+++ b/visualize_point_cloud.py
@@ -3,17 +3,15 @@ import os
 import numpy as np
 import helper
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 
 def VisualizePointCloud(data_file):
   points = helper.LoadDataFile(data_file)
   fig = plt.figure()
-  ax = Axes3D(fig)
+  ax = fig.add_subplot(111, projection='3d')
   ax.scatter(points[:, 0], points[:, 1], points[:, 2], c = 'r')
   ax.set_xlabel('x')
   ax.set_ylabel('y')
   ax.set_zlabel('z')
-  ax.set_aspect('equal')
   plt.show()
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR collects 7 commits making InverseCSG buildable and runnable on
current Linux distributions (tested on Ubuntu 22.04/24.04 in WSL2).
Each commit is focused and individually reviewable; they are independent
fixes rather than a refactor.

## Build-system updates (2 commits)

- `refactor(cmake): migrate to C++14, CGAL 5.x, system Eigen3` — CGAL 5
  requires C++14; switches to `find_package(CGAL)` with imported targets
  and prefers system Eigen3 with the vendored 3.3.4 as fallback.
- `refactor: modernize install script for current Ubuntu` — `install.py`
  updated for current apt package names, OpenJDK 11+, and Python 3.7+.

## Python pipeline correctness fixes (4 commits)

- `fix: update deprecated Python APIs for current versions` — adapts to
  removals/changes in numpy 1.24+, scikit-learn 1.x, and Python 3.10+.
- `fix: use communicate() to avoid subprocess deadlock` — `Popen.wait()`
  deadlocks when stdout fills the pipe buffer on larger meshes.
- `fix: prevent infinite loop on unsegmentable parts` — caps
  `n_clusters` at the actual sample count in `point_cloud_seg.py`
  (addresses the AgglomerativeClustering crash in upstream issue #1).
- `fix: check test exit codes and quote shell paths` — `run_tests.py`
  and `cpp/test.py` now propagate exit codes and quote paths.

## C++ test fix (1 commit)

- `fix: compute sphere radius in surface parameter test` —
  `test_initialize_surface_parameters.cpp` was reading the sphere
  radius before it was computed.

## Verification

`python3 run_tests.py build one_cube` now completes end-to-end in
seconds and writes `solution_0.scad` matching the reference.

## Compatibility notes

- Toolchain: gcc 11+, cmake 3.22+, CGAL 5.6, Eigen 3.4
- Tested on Ubuntu 22.04 and 24.04 (WSL2). 20.04 should also work but
  CGAL 5 is not in 20.04's default repos.
- Sketch frontend/backend versions referenced in `install.py` continue
  to build with these changes.